### PR TITLE
Refactor Go Sprintf statements using Comby

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -205,7 +205,7 @@ func ValidateDiscoveryKubeConfigPath(discoveryFile string, fldPath *field.Path) 
 func ValidateBootstrapTokens(bts []kubeadm.BootstrapToken, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	for i, bt := range bts {
-		btPath := fldPath.Child(fmt.Sprintf("%d", i))
+		btPath := fldPath.Child(strconv.Itoa(i))
 		allErrs = append(allErrs, ValidateToken(bt.Token.String(), btPath.Child(kubeadmcmdoptions.TokenStr))...)
 		allErrs = append(allErrs, ValidateTokenUsages(bt.Usages, btPath.Child(kubeadmcmdoptions.TokenUsages))...)
 		allErrs = append(allErrs, ValidateTokenGroups(bt.Usages, bt.Groups, btPath.Child(kubeadmcmdoptions.TokenGroups))...)

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -132,7 +132,7 @@ func getAPIServerCommand(cfg *kubeadmapi.ClusterConfiguration, localAPIEndpoint 
 		"kubelet-client-certificate":      filepath.Join(cfg.CertificatesDir, kubeadmconstants.APIServerKubeletClientCertName),
 		"kubelet-client-key":              filepath.Join(cfg.CertificatesDir, kubeadmconstants.APIServerKubeletClientKeyName),
 		"enable-bootstrap-token-auth":     "true",
-		"secure-port":                     fmt.Sprintf("%d", localAPIEndpoint.BindPort),
+		"secure-port":                     strconv.Itoa(localAPIEndpoint.BindPort),
 		"allow-privileged":                "true",
 		"kubelet-preferred-address-types": "InternalIP,ExternalIP,Hostname",
 		// add options to configure the front proxy.  Without the generated client cert, this will never be useable

--- a/pkg/apis/storage/fuzzer/fuzzer.go
+++ b/pkg/apis/storage/fuzzer/fuzzer.go
@@ -47,7 +47,7 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 			case 2:
 				// Invalid mode.
 				obj.Spec.VolumeLifecycleModes = []storage.VolumeLifecycleMode{
-					storage.VolumeLifecycleMode(fmt.Sprintf("%d", c.Rand.Int31())),
+					storage.VolumeLifecycleMode(strconv.Itoa(c.Rand.Int31())),
 				}
 			case 3:
 				obj.Spec.VolumeLifecycleModes = []storage.VolumeLifecycleMode{

--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -400,12 +400,12 @@ func SetReplicasAnnotations(rs *apps.ReplicaSet, desiredReplicas, maxReplicas in
 	if rs.Annotations == nil {
 		rs.Annotations = make(map[string]string)
 	}
-	desiredString := fmt.Sprintf("%d", desiredReplicas)
+	desiredString := strconv.Itoa(desiredReplicas)
 	if hasString := rs.Annotations[DesiredReplicasAnnotation]; hasString != desiredString {
 		rs.Annotations[DesiredReplicasAnnotation] = desiredString
 		updated = true
 	}
-	maxString := fmt.Sprintf("%d", maxReplicas)
+	maxString := strconv.Itoa(maxReplicas)
 	if hasString := rs.Annotations[MaxReplicasAnnotation]; hasString != maxString {
 		rs.Annotations[MaxReplicasAnnotation] = maxString
 		updated = true
@@ -418,11 +418,11 @@ func ReplicasAnnotationsNeedUpdate(rs *apps.ReplicaSet, desiredReplicas, maxRepl
 	if rs.Annotations == nil {
 		return true
 	}
-	desiredString := fmt.Sprintf("%d", desiredReplicas)
+	desiredString := strconv.Itoa(desiredReplicas)
 	if hasString := rs.Annotations[DesiredReplicasAnnotation]; hasString != desiredString {
 		return true
 	}
-	maxString := fmt.Sprintf("%d", maxReplicas)
+	maxString := strconv.Itoa(maxReplicas)
 	if hasString := rs.Annotations[MaxReplicasAnnotation]; hasString != maxString {
 		return true
 	}

--- a/pkg/controller/deployment/util/deployment_util_test.go
+++ b/pkg/controller/deployment/util/deployment_util_test.go
@@ -685,7 +685,7 @@ func TestResolveFenceposts(t *testing.T) {
 	}
 
 	for num, test := range tests {
-		t.Run(fmt.Sprintf("%d", num), func(t *testing.T) {
+		t.Run(strconv.Itoa(num), func(t *testing.T) {
 			var maxSurge, maxUnavail *intstr.IntOrString
 			if test.maxSurge != nil {
 				surge := intstr.FromString(*test.maxSurge)
@@ -1277,7 +1277,7 @@ func TestAnnotationUtils(t *testing.T) {
 		//Try to set the increment revision from 11 through 20
 		for i := 10; i < 20; i++ {
 
-			nextRevision := fmt.Sprintf("%d", i+1)
+			nextRevision := strconv.Itoa(i + 1)
 			SetNewReplicaSetAnnotations(&tDeployment, &tRS, nextRevision, true, 5)
 			//Now the ReplicaSets Revision Annotation should be i+1
 
@@ -1331,8 +1331,8 @@ func TestAnnotationUtils(t *testing.T) {
 
 func TestReplicasAnnotationsNeedUpdate(t *testing.T) {
 
-	desiredReplicas := fmt.Sprintf("%d", int32(10))
-	maxReplicas := fmt.Sprintf("%d", int32(20))
+	desiredReplicas := strconv.Itoa(int32(10))
+	maxReplicas := strconv.Itoa(int32(20))
 
 	tests := []struct {
 		name       string

--- a/pkg/kubectl/cmd/cp/cp_test.go
+++ b/pkg/kubectl/cmd/cp/cp_test.go
@@ -242,7 +242,7 @@ func TestIsDestRelative(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			if test.relative != isDestRelative(test.base, test.dest) {
 				t.Errorf("unexpected result for: base %q, dest %q", test.base, test.dest)
 			}

--- a/pkg/kubelet/dockershim/docker_container_test.go
+++ b/pkg/kubelet/dockershim/docker_container_test.go
@@ -60,7 +60,7 @@ func TestListContainers(t *testing.T) {
 	sConfigs := []*runtimeapi.PodSandboxConfig{}
 	for i := 0; i < 3; i++ {
 		s := makeSandboxConfig(fmt.Sprintf("%s%d", podName, i),
-			fmt.Sprintf("%s%d", namespace, i), fmt.Sprintf("%d", i), 0)
+			fmt.Sprintf("%s%d", namespace, i), strconv.Itoa(i), 0)
 		labels := map[string]string{"abc.xyz": fmt.Sprintf("label%d", i)}
 		annotations := map[string]string{"foo.bar.baz": fmt.Sprintf("annotation%d", i)}
 		c := makeContainerConfig(s, fmt.Sprintf("%s%d", containerName, i),

--- a/pkg/kubelet/dockershim/docker_sandbox_test.go
+++ b/pkg/kubelet/dockershim/docker_sandbox_test.go
@@ -60,7 +60,7 @@ func TestListSandboxes(t *testing.T) {
 	configs := []*runtimeapi.PodSandboxConfig{}
 	for i := 0; i < 3; i++ {
 		c := makeSandboxConfigWithLabelsAndAnnotations(fmt.Sprintf("%s%d", name, i),
-			fmt.Sprintf("%s%d", namespace, i), fmt.Sprintf("%d", i), 0,
+			fmt.Sprintf("%s%d", namespace, i), strconv.Itoa(i), 0,
 			map[string]string{"label": fmt.Sprintf("foo%d", i)},
 			map[string]string{"annotation": fmt.Sprintf("bar%d", i)},
 		)

--- a/pkg/kubelet/dockershim/docker_streaming_others.go
+++ b/pkg/kubelet/dockershim/docker_streaming_others.go
@@ -44,7 +44,7 @@ func (r *streamingRuntime) portForward(podSandboxID string, port int32, stream i
 		return fmt.Errorf("unable to do port forwarding: socat not found")
 	}
 
-	args := []string{"-t", fmt.Sprintf("%d", containerPid), "-n", socatPath, "-", fmt.Sprintf("TCP4:localhost:%d", port)}
+	args := []string{"-t", strconv.Itoa(containerPid), "-n", socatPath, "-", fmt.Sprintf("TCP4:localhost:%d", port)}
 
 	nsenterPath, lookupErr := exec.LookPath("nsenter")
 	if lookupErr != nil {

--- a/pkg/kubelet/dockershim/naming.go
+++ b/pkg/kubelet/dockershim/naming.go
@@ -57,23 +57,23 @@ const (
 
 func makeSandboxName(s *runtimeapi.PodSandboxConfig) string {
 	return strings.Join([]string{
-		kubePrefix,                            // 0
-		sandboxContainerName,                  // 1
-		s.Metadata.Name,                       // 2
-		s.Metadata.Namespace,                  // 3
-		s.Metadata.Uid,                        // 4
-		fmt.Sprintf("%d", s.Metadata.Attempt), // 5
+		kubePrefix,                       // 0
+		sandboxContainerName,             // 1
+		s.Metadata.Name,                  // 2
+		s.Metadata.Namespace,             // 3
+		s.Metadata.Uid,                   // 4
+		strconv.Itoa(s.Metadata.Attempt), // 5
 	}, nameDelimiter)
 }
 
 func makeContainerName(s *runtimeapi.PodSandboxConfig, c *runtimeapi.ContainerConfig) string {
 	return strings.Join([]string{
-		kubePrefix,                            // 0
-		c.Metadata.Name,                       // 1:
-		s.Metadata.Name,                       // 2: sandbox name
-		s.Metadata.Namespace,                  // 3: sandbox namesapce
-		s.Metadata.Uid,                        // 4  sandbox uid
-		fmt.Sprintf("%d", c.Metadata.Attempt), // 5
+		kubePrefix,                       // 0
+		c.Metadata.Name,                  // 1:
+		s.Metadata.Name,                  // 2: sandbox name
+		s.Metadata.Namespace,             // 3: sandbox namesapce
+		s.Metadata.Uid,                   // 4  sandbox uid
+		strconv.Itoa(c.Metadata.Attempt), // 5
 	}, nameDelimiter)
 }
 

--- a/pkg/kubelet/dockershim/network/hostport/hostport_manager.go
+++ b/pkg/kubelet/dockershim/network/hostport/hostport_manager.go
@@ -131,7 +131,7 @@ func (hm *hostportManager) Add(id string, podPortMapping *PodPortMapping, natInt
 		// This avoids any leaking iptables rule that takes up the same port
 		writeLine(natRules, "-I", string(kubeHostportsChain),
 			"-m", "comment", "--comment", fmt.Sprintf(`"%s hostport %d"`, podFullName, pm.HostPort),
-			"-m", protocol, "-p", protocol, "--dport", fmt.Sprintf("%d", pm.HostPort),
+			"-m", protocol, "-p", protocol, "--dport", strconv.Itoa(pm.HostPort),
 			"-j", string(chain),
 		)
 

--- a/pkg/kubelet/dockershim/network/hostport/hostport_syncer.go
+++ b/pkg/kubelet/dockershim/network/hostport/hostport_syncer.go
@@ -240,7 +240,7 @@ func (h *hostportSyncer) SyncHostports(natInterfaceName string, activePodPortMap
 			"-A", string(kubeHostportsChain),
 			"-m", "comment", "--comment", fmt.Sprintf(`"%s hostport %d"`, target.podFullName, port.HostPort),
 			"-m", protocol, "-p", protocol,
-			"--dport", fmt.Sprintf("%d", port.HostPort),
+			"--dport", strconv.Itoa(port.HostPort),
 			"-j", string(hostportChain),
 		}
 		writeLine(natRules, args...)

--- a/pkg/kubelet/pod_container_deletor.go
+++ b/pkg/kubelet/pod_container_deletor.go
@@ -37,9 +37,11 @@ type podContainerDeletor struct {
 	containersToKeep int
 }
 
-func (a containerStatusbyCreatedList) Len() int           { return len(a) }
-func (a containerStatusbyCreatedList) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a containerStatusbyCreatedList) Less(i, j int) bool { return a[i].CreatedAt.After(a[j].CreatedAt) }
+func (a containerStatusbyCreatedList) Len() int      { return len(a) }
+func (a containerStatusbyCreatedList) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a containerStatusbyCreatedList) Less(i, j int) bool {
+	return a[i].CreatedAt.After(a[j].CreatedAt)
+}
 
 func newPodContainerDeletor(runtime kubecontainer.Runtime, containersToKeep int) *podContainerDeletor {
 	buffer := make(chan kubecontainer.ContainerID, containerDeletorBufferLimit)

--- a/pkg/kubelet/server/remotecommand/exec.go
+++ b/pkg/kubelet/server/remotecommand/exec.go
@@ -60,7 +60,7 @@ func ServeExec(w http.ResponseWriter, req *http.Request, executor Executor, podN
 					Causes: []metav1.StatusCause{
 						{
 							Type:    remotecommandconsts.ExitCodeCauseType,
-							Message: fmt.Sprintf("%d", rc),
+							Message: strconv.Itoa(rc),
 						},
 					},
 				},

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -1753,7 +1753,7 @@ func printHorizontalPodAutoscaler(obj *autoscaling.HorizontalPodAutoscaler, opti
 	minPods := "<unset>"
 	metrics := formatHPAMetrics(obj.Spec.Metrics, obj.Status.CurrentMetrics)
 	if obj.Spec.MinReplicas != nil {
-		minPods = fmt.Sprintf("%d", *obj.Spec.MinReplicas)
+		minPods = strconv.Itoa(*obj.Spec.MinReplicas)
 	}
 	maxPods := obj.Spec.MaxReplicas
 	currentReplicas := obj.Status.CurrentReplicas

--- a/pkg/proxy/userspace/proxier.go
+++ b/pkg/proxy/userspace/proxier.go
@@ -1098,7 +1098,7 @@ func iptablesCommonPortalArgs(destIP net.IP, addPhysicalInterfaceMatch bool, add
 		"--comment", service.String(),
 		"-p", strings.ToLower(string(protocol)),
 		"-m", strings.ToLower(string(protocol)),
-		"--dport", fmt.Sprintf("%d", destPort),
+		"--dport", strconv.Itoa(destPort),
 	}
 
 	if destIP != nil {
@@ -1155,7 +1155,7 @@ func (proxier *Proxier) iptablesContainerPortalArgs(destIP net.IP, addPhysicalIn
 	// allowed.
 	if proxyIP.Equal(zeroIPv4) || proxyIP.Equal(zeroIPv6) {
 		// TODO: Can we REDIRECT with IPv6?
-		args = append(args, "-j", "REDIRECT", "--to-ports", fmt.Sprintf("%d", proxyPort))
+		args = append(args, "-j", "REDIRECT", "--to-ports", strconv.Itoa(proxyPort))
 	} else {
 		// TODO: Can we DNAT with IPv6?
 		args = append(args, "-j", "DNAT", "--to-destination", net.JoinHostPort(proxyIP.String(), strconv.Itoa(proxyPort)))

--- a/pkg/proxy/userspace/proxier_test.go
+++ b/pkg/proxy/userspace/proxier_test.go
@@ -47,7 +47,7 @@ const (
 )
 
 func joinHostPort(host string, port int) string {
-	return net.JoinHostPort(host, fmt.Sprintf("%d", port))
+	return net.JoinHostPort(host, strconv.Itoa(port))
 }
 
 func waitForClosedPortTCP(p *Proxier, proxyPort int) error {
@@ -176,7 +176,7 @@ func TestMain(m *testing.M) {
 
 func testEchoTCP(t *testing.T, address string, port int) {
 	path := "aaaaa"
-	res, err := http.Get("http://" + address + ":" + fmt.Sprintf("%d", port) + "/" + path)
+	res, err := http.Get("http://" + address + ":" + strconv.Itoa(port) + "/" + path)
 	if err != nil {
 		t.Fatalf("error connecting to server: %v", err)
 	}

--- a/pkg/proxy/winuserspace/proxier_test.go
+++ b/pkg/proxy/winuserspace/proxier_test.go
@@ -43,7 +43,7 @@ const (
 )
 
 func joinHostPort(host string, port int) string {
-	return net.JoinHostPort(host, fmt.Sprintf("%d", port))
+	return net.JoinHostPort(host, strconv.Itoa(port))
 }
 
 func waitForClosedPortTCP(p *Proxier, proxyPort int) error {
@@ -162,7 +162,7 @@ func TestMain(m *testing.M) {
 
 func testEchoTCP(t *testing.T, address string, port int) {
 	path := "aaaaa"
-	res, err := http.Get("http://" + address + ":" + fmt.Sprintf("%d", port) + "/" + path)
+	res, err := http.Get("http://" + address + ":" + strconv.Itoa(port) + "/" + path)
 	if err != nil {
 		t.Fatalf("error connecting to server: %v", err)
 	}

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -280,7 +280,7 @@ func ResourceLocation(getter ResourceGetter, rt http.RoundTripper, ctx context.C
 	if port == "" {
 		for i := range pod.Spec.Containers {
 			if len(pod.Spec.Containers[i].Ports) > 0 {
-				port = fmt.Sprintf("%d", pod.Spec.Containers[i].Ports[0].ContainerPort)
+				port = strconv.Itoa(pod.Spec.Containers[i].Ports[0].ContainerPort)
 				break
 			}
 		}

--- a/pkg/security/podsecuritypolicy/provider.go
+++ b/pkg/security/podsecuritypolicy/provider.go
@@ -423,7 +423,7 @@ func hostPortRangesToString(ranges []policy.HostPortRange) string {
 		strRanges := []string{}
 		for _, r := range ranges {
 			if r.Min == r.Max {
-				strRanges = append(strRanges, fmt.Sprintf("%d", r.Min))
+				strRanges = append(strRanges, strconv.Itoa(r.Min))
 			} else {
 				strRanges = append(strRanges, fmt.Sprintf("%d-%d", r.Min, r.Max))
 			}

--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -588,7 +588,7 @@ func (util *RBDUtil) CreateImage(p *rbdVolumeProvisioner) (r *v1.RBDPersistentVo
 	if err != nil {
 		return nil, 0, err
 	}
-	volSz := fmt.Sprintf("%d", sz)
+	volSz := strconv.Itoa(sz)
 	mon := util.kernelRBDMonitorsOpt(p.Mon)
 	if p.rbdMounter.imageFormat == rbdImageFormat2 {
 		klog.V(4).Infof("rbd: create %s size %s format %s (features: %s) using mon %s, pool %s id %s key %s", p.rbdMounter.Image, volSz, p.rbdMounter.imageFormat, p.rbdMounter.imageFeatures, mon, p.rbdMounter.Pool, p.rbdMounter.adminId, p.rbdMounter.adminSecret)
@@ -646,7 +646,7 @@ func (util *RBDUtil) ExpandImage(rbdExpander *rbdVolumeExpander, oldSize resourc
 
 	// Convert to MB that rbd defaults on.
 	sz := int(volumehelpers.RoundUpToMiB(newSize))
-	newVolSz := fmt.Sprintf("%d", sz)
+	newVolSz := strconv.Itoa(sz)
 	newSizeQuant := resource.MustParse(fmt.Sprintf("%dMi", sz))
 
 	// Check the current size of rbd image, if equals to or greater that the new request size, do nothing.

--- a/pkg/volume/util/fs/fs_windows.go
+++ b/pkg/volume/util/fs/fs_windows.go
@@ -69,7 +69,7 @@ func DiskUsage(path string) (*resource.Quantity, error) {
 		return nil, err
 	}
 
-	used, err := resource.ParseQuantity(fmt.Sprintf("%d", usage))
+	used, err := resource.ParseQuantity(strconv.Itoa(usage))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse fs usage %d due to %v", usage, err)
 	}

--- a/pkg/volume/util/fs/fs_windows_test.go
+++ b/pkg/volume/util/fs/fs_windows_test.go
@@ -70,7 +70,7 @@ func TestDiskUsage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
 	}
-	used, err := resource.ParseQuantity(fmt.Sprintf("%d", total))
+	used, err := resource.ParseQuantity(strconv.Itoa(total))
 	if err != nil {
 		t.Fatalf("TestDiskUsage failed: %s", err.Error())
 	}

--- a/plugin/pkg/admission/limitranger/admission_test.go
+++ b/plugin/pkg/admission/limitranger/admission_test.go
@@ -771,11 +771,11 @@ func newMockClientForTest(limitRanges []corev1.LimitRange) *fake.Clientset {
 	mockClient.AddReactor("list", "limitranges", func(action core.Action) (bool, runtime.Object, error) {
 		limitRangeList := &corev1.LimitRangeList{
 			ListMeta: metav1.ListMeta{
-				ResourceVersion: fmt.Sprintf("%d", len(limitRanges)),
+				ResourceVersion: strconv.Itoa(len(limitRanges)),
 			},
 		}
 		for index, value := range limitRanges {
-			value.ResourceVersion = fmt.Sprintf("%d", index)
+			value.ResourceVersion = strconv.Itoa(index)
 			limitRangeList.Items = append(limitRangeList.Items, value)
 		}
 		return true, limitRangeList, nil

--- a/plugin/pkg/admission/namespace/autoprovision/admission_test.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission_test.go
@@ -53,14 +53,14 @@ func newMockClientForTest(namespaces []string) *fake.Clientset {
 	mockClient.AddReactor("list", "namespaces", func(action core.Action) (bool, runtime.Object, error) {
 		namespaceList := &corev1.NamespaceList{
 			ListMeta: metav1.ListMeta{
-				ResourceVersion: fmt.Sprintf("%d", len(namespaces)),
+				ResourceVersion: strconv.Itoa(len(namespaces)),
 			},
 		}
 		for i, ns := range namespaces {
 			namespaceList.Items = append(namespaceList.Items, corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            ns,
-					ResourceVersion: fmt.Sprintf("%d", i),
+					ResourceVersion: strconv.Itoa(i),
 				},
 			})
 		}

--- a/plugin/pkg/admission/namespace/exists/admission_test.go
+++ b/plugin/pkg/admission/namespace/exists/admission_test.go
@@ -51,14 +51,14 @@ func newMockClientForTest(namespaces []string) *fake.Clientset {
 	mockClient.AddReactor("list", "namespaces", func(action core.Action) (bool, runtime.Object, error) {
 		namespaceList := &corev1.NamespaceList{
 			ListMeta: metav1.ListMeta{
-				ResourceVersion: fmt.Sprintf("%d", len(namespaces)),
+				ResourceVersion: strconv.Itoa(len(namespaces)),
 			},
 		}
 		for i, ns := range namespaces {
 			namespaceList.Items = append(namespaceList.Items, corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            ns,
-					ResourceVersion: fmt.Sprintf("%d", i),
+					ResourceVersion: strconv.Itoa(i),
 				},
 			})
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter_test.go
@@ -280,7 +280,7 @@ func TestRoundTrip(t *testing.T) {
 	}
 
 	for i := range testCases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			doRoundTrip(t, testCases[i].obj)
 		})
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
@@ -838,7 +838,7 @@ func TestConvertToVersion(t *testing.T) {
 		},
 	}
 	for i, test := range testCases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			original := test.in.DeepCopyObject()
 			out, err := test.scheme.ConvertToVersion(test.in, test.gv)
 			switch {
@@ -903,7 +903,7 @@ func TestConvert(t *testing.T) {
 		},
 	}
 	for i, test := range testCases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			err := test.scheme.Convert(test.in, test.into, test.gv)
 			switch {
 			case test.errFn != nil:

--- a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
@@ -201,7 +201,7 @@ func (v *Version) String() string {
 		if i > 0 {
 			buffer.WriteString(".")
 		}
-		buffer.WriteString(fmt.Sprintf("%d", comp))
+		buffer.WriteString(strconv.Itoa(comp))
 	}
 	if v.preRelease != "" {
 		buffer.WriteString("-")

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
@@ -64,7 +64,7 @@ func newMockClientForTest(namespaces map[string]v1.NamespacePhase) *fake.Clients
 	mockClient.AddReactor("list", "namespaces", func(action core.Action) (bool, runtime.Object, error) {
 		namespaceList := &v1.NamespaceList{
 			ListMeta: metav1.ListMeta{
-				ResourceVersion: fmt.Sprintf("%d", len(namespaces)),
+				ResourceVersion: strconv.Itoa(len(namespaces)),
 			},
 		}
 		index := 0
@@ -72,7 +72,7 @@ func newMockClientForTest(namespaces map[string]v1.NamespacePhase) *fake.Clients
 			namespaceList.Items = append(namespaceList.Items, v1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            name,
-					ResourceVersion: fmt.Sprintf("%d", index),
+					ResourceVersion: strconv.Itoa(index),
 				},
 				Status: v1.NamespaceStatus{
 					Phase: phase,

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -1998,7 +1998,7 @@ func TestGetTable(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			storage := map[string]rest.Storage{}
 			simpleStorage := SimpleRESTStorage{
 				item: obj,
@@ -2208,7 +2208,7 @@ func TestWatchTable(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			storage := map[string]rest.Storage{}
 			simpleStorage := SimpleRESTStorage{
 				item: obj,

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/util.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/util.go
@@ -43,7 +43,7 @@ func GetHumanCertDetail(certificate *x509.Certificate) string {
 			continue
 		}
 
-		usages = append(usages, fmt.Sprintf("%d", curr))
+		usages = append(usages, strconv.Itoa(curr))
 	}
 
 	validServingNames := []string{}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/deprecated_insecure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/deprecated_insecure_serving.go
@@ -112,7 +112,7 @@ func (s *DeprecatedInsecureServingOptions) ApplyTo(c **server.DeprecatedInsecure
 		if s.ListenFunc != nil {
 			listen = s.ListenFunc
 		}
-		addr := net.JoinHostPort(s.BindAddress.String(), fmt.Sprintf("%d", s.BindPort))
+		addr := net.JoinHostPort(s.BindAddress.String(), strconv.Itoa(s.BindPort))
 		s.Listener, s.BindPort, err = listen(s.BindNetwork, addr)
 		if err != nil {
 			return fmt.Errorf("failed to create listener: %v", err)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -406,7 +406,7 @@ func TestWatcherNotGoingBackInTime(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            fmt.Sprintf("pod-%d", 1000+i),
 				Namespace:       "ns",
-				ResourceVersion: fmt.Sprintf("%d", 1000+i),
+				ResourceVersion: strconv.Itoa(1000+i),
 			},
 		}
 	}
@@ -839,7 +839,7 @@ func TestDispatchEventWillNotBeBlockedByTimedOutWatcher(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            fmt.Sprintf("pod-%d", 1000+i),
 				Namespace:       "ns",
-				ResourceVersion: fmt.Sprintf("%d", 1000+i),
+				ResourceVersion: strconv.Itoa(1000+i),
 			},
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go
@@ -125,7 +125,7 @@ func TestCachingObjectRaces(t *testing.T) {
 
 	encoders := []*mockEncoder{}
 	for i := 0; i < 10; i++ {
-		encoder := newMockEncoder(fmt.Sprintf("%d", i), "result", nil)
+		encoder := newMockEncoder(strconv.Itoa(i), "result", nil)
 		encoders = append(encoders, encoder)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -217,17 +217,17 @@ func TestGet(t *testing.T) {
 		name:        "current object resource version",
 		key:         key,
 		expectedOut: storedObj,
-		rv:          fmt.Sprintf("%d", currentRV),
+		rv:          strconv.Itoa(currentRV),
 	}, { // test get on existing item with minimum resource version set to latest pod resource version
 		name:        "latest resource version",
 		key:         key,
 		expectedOut: storedObj,
-		rv:          fmt.Sprintf("%d", lastUpdatedCurrentRV),
+		rv:          strconv.Itoa(lastUpdatedCurrentRV),
 	}, { // test get on existing item with minimum resource version set too high
 		name:             "too high resource version",
 		key:              key,
 		expectRVTooLarge: true,
-		rv:               fmt.Sprintf("%d", lastUpdatedCurrentRV+1),
+		rv:               strconv.Itoa(lastUpdatedCurrentRV+1),
 	}, { // test get on non-existing item with ignoreNotFound=false
 		name:              "get non-existing",
 		key:               "/non-existing",
@@ -365,12 +365,12 @@ func TestGetToList(t *testing.T) {
 		key:         key,
 		pred:        storage.Everything,
 		expectedOut: []*example.Pod{storedObj},
-		rv:          fmt.Sprintf("%d", currentRV),
+		rv:          strconv.Itoa(currentRV),
 	}, { // test GetToList on existing key with minimum resource version set too high
 		key:              key,
 		pred:             storage.Everything,
 		expectedOut:      []*example.Pod{storedObj},
-		rv:               fmt.Sprintf("%d", currentRV+1),
+		rv:               strconv.Itoa(currentRV+1),
 		expectRVTooLarge: true,
 	}, { // test GetToList on non-existing key
 		key:         "/non-existing",
@@ -933,7 +933,7 @@ func TestList(t *testing.T) {
 		{
 			name:             "rejects resource version set too high",
 			prefix:           "/",
-			rv:               fmt.Sprintf("%d", continueRV+1),
+			rv:               strconv.Itoa(continueRV+1),
 			expectRVTooLarge: true,
 		},
 		{

--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/proxy.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/proxy.go
@@ -106,12 +106,12 @@ func ResolveCluster(services listersv1.ServiceLister, namespace, id string, port
 		}
 		return &url.URL{
 			Scheme: "https",
-			Host:   net.JoinHostPort(svc.Spec.ClusterIP, fmt.Sprintf("%d", svcPort.Port)),
+			Host:   net.JoinHostPort(svc.Spec.ClusterIP, strconv.Itoa(svcPort.Port)),
 		}, nil
 	case svc.Spec.Type == v1.ServiceTypeExternalName:
 		return &url.URL{
 			Scheme: "https",
-			Host:   net.JoinHostPort(svc.Spec.ExternalName, fmt.Sprintf("%d", port)),
+			Host:   net.JoinHostPort(svc.Spec.ExternalName, strconv.Itoa(port)),
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported service type %q", svc.Spec.Type)

--- a/staging/src/k8s.io/client-go/rest/plugin_test.go
+++ b/staging/src/k8s.io/client-go/rest/plugin_test.go
@@ -283,7 +283,7 @@ func (w *wrapTransportPersist) RoundTrip(req *http.Request) (*http.Response, err
 		}
 	}
 	roundTrips++
-	w.config["roundTrips"] = fmt.Sprintf("%d", roundTrips)
+	w.config["roundTrips"] = strconv.Itoa(roundTrips)
 	if err := w.persister.Persist(w.config); err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -409,7 +409,7 @@ func TestReflectorWatchListPageSize(t *testing.T) {
 			}
 			pods := make([]v1.Pod, 10)
 			for i := 0; i < 10; i++ {
-				pods[i] = v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod-%d", i), ResourceVersion: fmt.Sprintf("%d", i)}}
+				pods[i] = v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod-%d", i), ResourceVersion: strconv.Itoa(i)}}
 			}
 			switch options.Continue {
 			case "":
@@ -454,7 +454,7 @@ func TestReflectorResyncWithResourceVersion(t *testing.T) {
 			listCallRVs = append(listCallRVs, options.ResourceVersion)
 			pods := make([]v1.Pod, 8)
 			for i := 0; i < 8; i++ {
-				pods[i] = v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod-%d", i), ResourceVersion: fmt.Sprintf("%d", i)}}
+				pods[i] = v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod-%d", i), ResourceVersion: strconv.Itoa(i)}}
 			}
 			switch options.ResourceVersion {
 			case "0":
@@ -513,7 +513,7 @@ func TestReflectorExpiredExactResourceVersion(t *testing.T) {
 			listCallRVs = append(listCallRVs, options.ResourceVersion)
 			pods := make([]v1.Pod, 8)
 			for i := 0; i < 8; i++ {
-				pods[i] = v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod-%d", i), ResourceVersion: fmt.Sprintf("%d", i)}}
+				pods[i] = v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod-%d", i), ResourceVersion: strconv.Itoa(i)}}
 			}
 			switch options.ResourceVersion {
 			case "0":
@@ -570,7 +570,7 @@ func TestReflectorFullListIfExpired(t *testing.T) {
 			listCallRVs = append(listCallRVs, options.ResourceVersion)
 			pods := make([]v1.Pod, 8)
 			for i := 0; i < 8; i++ {
-				pods[i] = v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod-%d", i), ResourceVersion: fmt.Sprintf("%d", i)}}
+				pods[i] = v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod-%d", i), ResourceVersion: strconv.Itoa(i)}}
 			}
 			switch options.ResourceVersion {
 			case "0":

--- a/staging/src/k8s.io/client-go/tools/pager/pager_test.go
+++ b/staging/src/k8s.io/client-go/tools/pager/pager_test.go
@@ -35,7 +35,7 @@ func list(count int, rv string) *metainternalversion.List {
 	for i := 0; i < count; i++ {
 		list.Items = append(list.Items, &metav1beta1.PartialObjectMetadata{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("%d", i),
+				Name: strconv.Itoa(i),
 			},
 		})
 	}
@@ -83,7 +83,7 @@ func (p *testPager) PagedList(ctx context.Context, options metav1.ListOptions) (
 		}
 		list.Items = append(list.Items, &metav1beta1.PartialObjectMetadata{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("%d", p.index),
+				Name: strconv.Itoa(p.index),
 			},
 		})
 		p.remaining--

--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -333,7 +333,7 @@ func (pf *PortForwarder) handleConnection(conn net.Conn, port ForwardedPort) {
 	// create error stream
 	headers := http.Header{}
 	headers.Set(v1.StreamType, v1.StreamTypeError)
-	headers.Set(v1.PortHeader, fmt.Sprintf("%d", port.Remote))
+	headers.Set(v1.PortHeader, strconv.Itoa(port.Remote))
 	headers.Set(v1.PortForwardRequestIDHeader, strconv.Itoa(requestID))
 	errorStream, err := pf.streamConn.CreateStream(headers)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
@@ -68,7 +68,7 @@ func makeTestEvent(rv int) watch.Event {
 	return watch.Event{
 		Type: watch.Added,
 		Object: testObject{
-			resourceVersion: fmt.Sprintf("%d", rv),
+			resourceVersion: strconv.Itoa(rv),
 		},
 	}
 }

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
@@ -221,7 +221,7 @@ func BenchmarkDelayingQueue_AddAfter(b *testing.B) {
 
 	// Add items
 	for n := 0; n < b.N; n++ {
-		data := fmt.Sprintf("%d", n)
+		data := strconv.Itoa(n)
 		q.AddAfter(data, time.Duration(rand.Int63n(int64(10*time.Minute))))
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/apply/parse/list_element.go
+++ b/staging/src/k8s.io/kubectl/pkg/apply/parse/list_element.go
@@ -76,7 +76,7 @@ func (v ElementBuildingVisitor) doPrimitiveList(meta apply.FieldMetaImpl, item *
 			s = item.Array.SubType
 		}
 
-		subitem, err := v.getItem(s, fmt.Sprintf("%d", i), l.RawElementData)
+		subitem, err := v.getItem(s, strconv.Itoa(i), l.RawElementData)
 
 		if err != nil {
 			return nil, err
@@ -132,7 +132,7 @@ func (v ElementBuildingVisitor) doMapList(meta apply.FieldMetaImpl, item *listIt
 		if item.Array != nil && item.Array.SubType != nil {
 			s = item.Array.SubType
 		}
-		subitem, err := v.getItem(s, fmt.Sprintf("%d", i), l.RawElementData)
+		subitem, err := v.getItem(s, strconv.Itoa(i), l.RawElementData)
 		if err != nil {
 			return nil, err
 		}
@@ -180,7 +180,7 @@ func (v ElementBuildingVisitor) replaceListElement(meta apply.FieldMetaImpl, ite
 		if item.Array != nil && item.Array.SubType != nil {
 			s = item.Array.SubType
 		}
-		subitem, err := v.getItem(s, fmt.Sprintf("%d", i), data)
+		subitem, err := v.getItem(s, strconv.Itoa(i), data)
 		if err != nil {
 			return nil, err
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollingupdate/rolling_updater.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollingupdate/rolling_updater.go
@@ -479,7 +479,7 @@ func (r *RollingUpdater) getOrCreateTargetControllerWithClient(controller *corev
 		if controller.Annotations == nil {
 			controller.Annotations = map[string]string{}
 		}
-		controller.Annotations[desiredReplicasAnnotation] = fmt.Sprintf("%d", valOrZero(controller.Spec.Replicas))
+		controller.Annotations[desiredReplicasAnnotation] = strconv.Itoa(valOrZero(controller.Spec.Replicas))
 		controller.Annotations[sourceIDAnnotation] = sourceID
 		controller.Spec.Replicas = utilpointer.Int32Ptr(0)
 		newRc, err := r.rcClient.ReplicationControllers(r.ns).Create(controller)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollingupdate/rolling_updater_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollingupdate/rolling_updater_test.go
@@ -54,7 +54,7 @@ func oldRc(replicas int, original int) *corev1.ReplicationController {
 			Name:      "foo-v1",
 			UID:       "7764ae47-9092-11e4-8393-42010af018ff",
 			Annotations: map[string]string{
-				originalReplicasAnnotation: fmt.Sprintf("%d", original),
+				originalReplicasAnnotation: strconv.Itoa(original),
 			},
 		},
 		Spec: corev1.ReplicationControllerSpec{
@@ -86,7 +86,7 @@ func newRc(replicas int, desired int) *corev1.ReplicationController {
 		Namespace: metav1.NamespaceDefault,
 		Name:      "foo-v2",
 		Annotations: map[string]string{
-			desiredReplicasAnnotation: fmt.Sprintf("%d", desired),
+			desiredReplicasAnnotation: strconv.Itoa(desired),
 			sourceIDAnnotation:        "foo-v1:7764ae47-9092-11e4-8393-42010af018ff",
 		},
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources_test.go
@@ -464,7 +464,7 @@ func TestSetResourcesRemote(t *testing.T) {
 	}
 
 	for i, input := range inputs {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			tf := cmdtesting.NewTestFactory().WithNamespace("test")
 			defer tf.Cleanup()
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount_test.go
@@ -65,7 +65,7 @@ func TestSetServiceAccountLocal(t *testing.T) {
 	}
 
 	for i, input := range inputs {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			tf := cmdtesting.NewTestFactory().WithNamespace("test")
 			defer tf.Cleanup()
 
@@ -317,7 +317,7 @@ func TestSetServiceAccountRemote(t *testing.T) {
 		},
 	}
 	for i, input := range inputs {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			tf := cmdtesting.NewTestFactory().WithNamespace("test")
 			defer tf.Cleanup()
 

--- a/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
@@ -3387,7 +3387,7 @@ func describeHorizontalPodAutoscalerV2beta2(hpa *autoscalingv2beta2.HorizontalPo
 		}
 		minReplicas := "<unset>"
 		if hpa.Spec.MinReplicas != nil {
-			minReplicas = fmt.Sprintf("%d", *hpa.Spec.MinReplicas)
+			minReplicas = strconv.Itoa(*hpa.Spec.MinReplicas)
 		}
 		w.Write(LEVEL_0, "Min replicas:\t%s\n", minReplicas)
 		w.Write(LEVEL_0, "Max replicas:\t%d\n", hpa.Spec.MaxReplicas)
@@ -3427,14 +3427,14 @@ func describeHorizontalPodAutoscalerV1(hpa *autoscalingv1.HorizontalPodAutoscale
 			w.Write(LEVEL_0, "Target CPU utilization:\t%d%%\n", *hpa.Spec.TargetCPUUtilizationPercentage)
 			current := "<unknown>"
 			if hpa.Status.CurrentCPUUtilizationPercentage != nil {
-				current = fmt.Sprintf("%d", *hpa.Status.CurrentCPUUtilizationPercentage)
+				current = strconv.Itoa(*hpa.Status.CurrentCPUUtilizationPercentage)
 			}
 			w.Write(LEVEL_0, "Current CPU utilization:\t%s%%\n", current)
 		}
 
 		minReplicas := "<unset>"
 		if hpa.Spec.MinReplicas != nil {
-			minReplicas = fmt.Sprintf("%d", *hpa.Spec.MinReplicas)
+			minReplicas = strconv.Itoa(*hpa.Spec.MinReplicas)
 		}
 		w.Write(LEVEL_0, "Min replicas:\t%s\n", minReplicas)
 		w.Write(LEVEL_0, "Max replicas:\t%d\n", hpa.Spec.MaxReplicas)

--- a/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe_test.go
@@ -842,7 +842,7 @@ func TestDescribeContainers(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			out := new(bytes.Buffer)
 			pod := corev1.Pod{
 				Spec: corev1.PodSpec{
@@ -2732,7 +2732,7 @@ func TestPrintLabelsMultiline(t *testing.T) {
 		},
 	}
 	for i, testCase := range testCases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			out := new(bytes.Buffer)
 			writer := NewPrefixWriter(out)
 			printAnnotationsMultiline(writer, "Annotations", testCase.annotations)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -1203,7 +1203,7 @@ func getTestSecurityGroup(az *Cloud, services ...v1.Service) *network.SecurityGr
 					Name: to.StringPtr(ruleName),
 					SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 						SourceAddressPrefix:  to.StringPtr(src),
-						DestinationPortRange: to.StringPtr(fmt.Sprintf("%d", port.Port)),
+						DestinationPortRange: to.StringPtr(strconv.Itoa(port.Port)),
 					},
 				})
 			}
@@ -1435,7 +1435,7 @@ func securityRuleMatches(serviceSourceRange string, servicePort v1.ServicePort, 
 		return fmt.Errorf("Rule does not contain source %s", serviceSourceRange)
 	}
 
-	if !contains(*rulePorts, fmt.Sprintf("%d", servicePort.Port)) {
+	if !contains(*rulePorts, strconv.Itoa(servicePort.Port)) {
 		return fmt.Errorf("Rule does not contain port %d", servicePort.Port)
 	}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
@@ -457,7 +457,7 @@ func getScaleSetVMInstanceID(machineName string) (string, error) {
 		return "", ErrorNotVmssInstance
 	}
 
-	return fmt.Sprintf("%d", instanceID), nil
+	return strconv.Itoa(instanceID), nil
 }
 
 // extractScaleSetNameByProviderID extracts the scaleset name by vmss node's ProviderID.

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_test.go
@@ -73,7 +73,7 @@ func setTestVirtualMachineCloud(ss *Cloud, scaleSetName, zone string, faultDomai
 		ID := fmt.Sprintf("/subscriptions/script/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%d", scaleSetName, i)
 		interfaceID := fmt.Sprintf("/subscriptions/script/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%d/networkInterfaces/%s", scaleSetName, i, nodeName)
 		publicAddressID := fmt.Sprintf("/subscriptions/script/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%d/networkInterfaces/%s/ipConfigurations/ipconfig1/publicIPAddresses/%s", scaleSetName, i, nodeName, nodeName)
-		instanceID := fmt.Sprintf("%d", i)
+		instanceID := strconv.Itoa(i)
 		vmName := fmt.Sprintf("%s_%s", scaleSetName, instanceID)
 
 		// set vmss virtual machine.

--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -144,8 +144,8 @@ var _ = SIGDescribe("ResourceQuota", func() {
 			found = len(secrets.Items)
 			return false, nil
 		})
-		defaultSecrets := fmt.Sprintf("%d", found)
-		hardSecrets := fmt.Sprintf("%d", found+1)
+		defaultSecrets := strconv.Itoa(found)
+		hardSecrets := strconv.Itoa(found + 1)
 
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(f.ClientSet, f.Namespace.Name)
@@ -309,8 +309,8 @@ var _ = SIGDescribe("ResourceQuota", func() {
 			found = len(configmaps.Items)
 			return false, nil
 		})
-		defaultConfigMaps := fmt.Sprintf("%d", found)
-		hardConfigMaps := fmt.Sprintf("%d", found+1)
+		defaultConfigMaps := strconv.Itoa(found)
+		hardConfigMaps := strconv.Itoa(found + 1)
 
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(f.ClientSet, f.Namespace.Name)

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -549,7 +549,7 @@ func testIterativeDeployments(f *framework.Framework) {
 			// trigger a new deployment
 			framework.Logf("%02d: triggering a new rollout for deployment %q", i, deployment.Name)
 			deployment, err = e2edeploy.UpdateDeploymentWithRetries(c, ns, deployment.Name, func(update *appsv1.Deployment) {
-				newEnv := v1.EnvVar{Name: "A", Value: fmt.Sprintf("%d", i)}
+				newEnv := v1.EnvVar{Name: "A", Value: strconv.Itoa(i)}
 				update.Spec.Template.Spec.Containers[0].Env = append(update.Spec.Template.Spec.Containers[0].Env, newEnv)
 				randomScale(update, i)
 			})
@@ -942,7 +942,7 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framew
 	for i := 1; i <= 3; i++ {
 		framework.Logf("Updating label deployment %q pod spec (iteration #%d)", name, i)
 		deployment, err = e2edeploy.UpdateDeploymentWithRetries(c, ns, d.Name, func(update *appsv1.Deployment) {
-			update.Spec.Template.Labels["iteration"] = fmt.Sprintf("%d", i)
+			update.Spec.Template.Labels["iteration"] = strconv.Itoa(i)
 			setAffinities(update, true)
 		})
 		framework.ExpectNoError(err)

--- a/test/e2e/framework/providers/gce/firewall.go
+++ b/test/e2e/framework/providers/gce/firewall.go
@@ -83,7 +83,7 @@ func ConstructHealthCheckFirewallForLBService(clusterID string, svc *v1.Service,
 	fw.Allowed = []*compute.FirewallAllowed{
 		{
 			IPProtocol: "tcp",
-			Ports:      []string{fmt.Sprintf("%d", healthCheckPort)},
+			Ports:      []string{strconv.Itoa(healthCheckPort)},
 		},
 	}
 	return &fw

--- a/test/e2e/network/scale/ingress.go
+++ b/test/e2e/network/scale/ingress.go
@@ -196,7 +196,7 @@ func (f *IngressScaleFramework) RunScaleTest() []error {
 		latencyQueue := make(chan time.Duration, numIngsToCreate)
 		start := time.Now()
 		for ; numIngsCreated < numIngsNeeded; numIngsCreated++ {
-			suffix := fmt.Sprintf("%d", numIngsCreated)
+			suffix := strconv.Itoa(numIngsCreated)
 			go func() {
 				defer ingWg.Done()
 
@@ -252,7 +252,7 @@ func (f *IngressScaleFramework) RunScaleTest() []error {
 	measureCreateUpdateFunc := func() {
 		f.Logger.Infof("Create one more ingress and wait for it to come up")
 		start := time.Now()
-		svcCreated, ingCreated, err := f.createScaleTestServiceIngress(fmt.Sprintf("%d", numIngsCreated), f.EnableTLS)
+		svcCreated, ingCreated, err := f.createScaleTestServiceIngress(strconv.Itoa(numIngsCreated), f.EnableTLS)
 		numIngsCreated = numIngsCreated + 1
 		f.ScaleTestSvcs = append(f.ScaleTestSvcs, svcCreated)
 		f.ScaleTestIngs = append(f.ScaleTestIngs, ingCreated)

--- a/test/e2e/network/scale/localrun/ingress_scale.go
+++ b/test/e2e/network/scale/localrun/ingress_scale.go
@@ -51,7 +51,7 @@ var (
 type numIngressesSlice []int
 
 func (i *numIngressesSlice) String() string {
-	return fmt.Sprintf("%d", *i)
+	return strconv.Itoa(*i)
 }
 
 func (i *numIngressesSlice) Set(value string) error {

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1432,7 +1432,7 @@ var _ = SIGDescribe("Services", func() {
 			Lifecycle: &v1.Lifecycle{
 				PreStop: &v1.Handler{
 					Exec: &v1.ExecAction{
-						Command: []string{"/bin/sleep", fmt.Sprintf("%d", terminateSeconds)},
+						Command: []string{"/bin/sleep", strconv.Itoa(terminateSeconds)},
 					},
 				},
 			},

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -335,7 +335,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				betaTest = &test
 
 				ginkgo.By("Testing " + test.Name)
-				suffix := fmt.Sprintf("%d", i)
+				suffix := strconv.Itoa(i)
 				test.Client = c
 				test.Class = newStorageClass(test, ns, suffix)
 				test.Claim = e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{

--- a/test/e2e_node/eviction_test.go
+++ b/test/e2e_node/eviction_test.go
@@ -78,7 +78,7 @@ var _ = framework.KubeDescribe("InodeEviction [Slow] [Serial] [Disruptive][NodeF
 			if inodesFree <= inodesConsumed {
 				framework.Skipf("Too few inodes free on the host for the InodeEviction test to run")
 			}
-			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalNodeFsInodesFree): fmt.Sprintf("%d", inodesFree-inodesConsumed)}
+			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalNodeFsInodesFree): strconv.Itoa(inodesFree - inodesConsumed)}
 			initialConfig.EvictionMinimumReclaim = map[string]string{}
 		})
 		runEvictionTest(f, pressureTimeout, expectedNodeCondition, expectedStarvedResource, logInodeMetrics, []podEvictSpec{
@@ -114,7 +114,7 @@ var _ = framework.KubeDescribe("ImageGCNoEviction [Slow] [Serial] [Disruptive][N
 			if inodesFree <= inodesConsumed {
 				framework.Skipf("Too few inodes free on the host for the InodeEviction test to run")
 			}
-			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalNodeFsInodesFree): fmt.Sprintf("%d", inodesFree-inodesConsumed)}
+			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalNodeFsInodesFree): strconv.Itoa(inodesFree - inodesConsumed)}
 			initialConfig.EvictionMinimumReclaim = map[string]string{}
 		})
 		// Consume enough inodes to induce disk pressure,
@@ -173,7 +173,7 @@ var _ = framework.KubeDescribe("LocalStorageEviction [Slow] [Serial] [Disruptive
 			diskConsumed := resource.MustParse("200Mi")
 			summary := eventuallyGetSummary()
 			availableBytes := *(summary.Node.Fs.AvailableBytes)
-			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalNodeFsAvailable): fmt.Sprintf("%d", availableBytes-uint64(diskConsumed.Value()))}
+			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalNodeFsAvailable): strconv.Itoa(availableBytes - uint64(diskConsumed.Value()))}
 			initialConfig.EvictionMinimumReclaim = map[string]string{}
 		})
 		runEvictionTest(f, pressureTimeout, expectedNodeCondition, expectedStarvedResource, logDiskMetrics, []podEvictSpec{
@@ -205,7 +205,7 @@ var _ = framework.KubeDescribe("LocalStorageSoftEviction [Slow] [Serial] [Disrup
 			if availableBytes <= uint64(diskConsumed.Value()) {
 				framework.Skipf("Too little disk free on the host for the LocalStorageSoftEviction test to run")
 			}
-			initialConfig.EvictionSoft = map[string]string{string(evictionapi.SignalNodeFsAvailable): fmt.Sprintf("%d", availableBytes-uint64(diskConsumed.Value()))}
+			initialConfig.EvictionSoft = map[string]string{string(evictionapi.SignalNodeFsAvailable): strconv.Itoa(availableBytes - uint64(diskConsumed.Value()))}
 			initialConfig.EvictionSoftGracePeriod = map[string]string{string(evictionapi.SignalNodeFsAvailable): "1m"}
 			// Defer to the pod default grace period
 			initialConfig.EvictionMaxPodGracePeriod = 30
@@ -297,7 +297,7 @@ var _ = framework.KubeDescribe("PriorityMemoryEvictionOrdering [Slow] [Serial] [
 			if availableBytes <= uint64(memoryConsumed.Value()) {
 				framework.Skipf("Too little memory free on the host for the PriorityMemoryEvictionOrdering test to run")
 			}
-			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalMemoryAvailable): fmt.Sprintf("%d", availableBytes-uint64(memoryConsumed.Value()))}
+			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalMemoryAvailable): strconv.Itoa(availableBytes - uint64(memoryConsumed.Value()))}
 			initialConfig.EvictionMinimumReclaim = map[string]string{}
 		})
 		ginkgo.BeforeEach(func() {
@@ -354,7 +354,7 @@ var _ = framework.KubeDescribe("PriorityLocalStorageEvictionOrdering [Slow] [Ser
 			if availableBytes <= uint64(diskConsumed.Value()) {
 				framework.Skipf("Too little disk free on the host for the PriorityLocalStorageEvictionOrdering test to run")
 			}
-			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalNodeFsAvailable): fmt.Sprintf("%d", availableBytes-uint64(diskConsumed.Value()))}
+			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalNodeFsAvailable): strconv.Itoa(availableBytes - uint64(diskConsumed.Value()))}
 			initialConfig.EvictionMinimumReclaim = map[string]string{}
 		})
 		ginkgo.BeforeEach(func() {
@@ -407,7 +407,7 @@ var _ = framework.KubeDescribe("PriorityPidEvictionOrdering [Slow] [Serial] [Dis
 			pidsConsumed := int64(10000)
 			summary := eventuallyGetSummary()
 			availablePids := *(summary.Node.Rlimit.MaxPID) - *(summary.Node.Rlimit.NumOfRunningProcesses)
-			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalPIDAvailable): fmt.Sprintf("%d", availablePids-pidsConsumed)}
+			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalPIDAvailable): strconv.Itoa(availablePids - pidsConsumed)}
 			initialConfig.EvictionMinimumReclaim = map[string]string{}
 		})
 		ginkgo.BeforeEach(func() {

--- a/test/e2e_node/restart_test.go
+++ b/test/e2e_node/restart_test.go
@@ -106,12 +106,12 @@ var _ = framework.KubeDescribe("Restart [Serial] [Slow] [Disruptive] [NodeFeatur
 						}
 						// Make sure the container runtime is running, pid got from pid file may not be running.
 						pid = runtimePids[0]
-						if _, err := exec.Command("sudo", "ps", "-p", fmt.Sprintf("%d", pid)).CombinedOutput(); err != nil {
+						if _, err := exec.Command("sudo", "ps", "-p", strconv.Itoa(pid)).CombinedOutput(); err != nil {
 							return err
 						}
 						return nil
 					}, 1*time.Minute, 2*time.Second).Should(gomega.BeNil())
-					if stdout, err := exec.Command("sudo", "kill", fmt.Sprintf("%d", pid)).CombinedOutput(); err != nil {
+					if stdout, err := exec.Command("sudo", "kill", strconv.Itoa(pid)).CombinedOutput(); err != nil {
 						framework.Failf("Failed to kill container runtime (pid=%d): %v, stdout: %q", pid, err, string(stdout))
 					}
 					// Assume that container runtime will be restarted by systemd/supervisord etc.

--- a/test/e2e_node/system_node_critical_test.go
+++ b/test/e2e_node/system_node_critical_test.go
@@ -43,7 +43,7 @@ var _ = framework.KubeDescribe("SystemNodeCriticalPod [Slow] [Serial] [Disruptiv
 			diskConsumed := resource.MustParse("200Mi")
 			summary := eventuallyGetSummary()
 			availableBytes := *(summary.Node.Fs.AvailableBytes)
-			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalNodeFsAvailable): fmt.Sprintf("%d", availableBytes-uint64(diskConsumed.Value()))}
+			initialConfig.EvictionHard = map[string]string{string(evictionapi.SignalNodeFsAvailable): strconv.Itoa(availableBytes - uint64(diskConsumed.Value()))}
 			initialConfig.EvictionMinimumReclaim = map[string]string{}
 		})
 

--- a/test/images/sample-device-plugin/sampledeviceplugin.go
+++ b/test/images/sample-device-plugin/sampledeviceplugin.go
@@ -84,7 +84,7 @@ func main() {
 		klog.Errorf("Empty pluginSocksDir")
 		return
 	}
-	socketPath := pluginSocksDir + "/dp." + fmt.Sprintf("%d", time.Now().Unix())
+	socketPath := pluginSocksDir + "/dp." + strconv.Itoa(time.Now().Unix())
 
 	dp1 := dm.NewDevicePluginStub(devs, socketPath, resourceName, false)
 	if err := dp1.Start(); err != nil {

--- a/test/integration/apimachinery/watch_restart_test.go
+++ b/test/integration/apimachinery/watch_restart_test.go
@@ -126,7 +126,7 @@ func TestWatchRestartsIfTimeoutNotReached(t *testing.T) {
 					t.Fatalf("Failed to patch secret: %v", err)
 				}
 
-				*referenceOutput = append(*referenceOutput, fmt.Sprintf("%d", counter))
+				*referenceOutput = append(*referenceOutput, strconv.Itoa(counter))
 			case <-endChannel:
 				return
 			case <-stopChan:

--- a/test/integration/scheduler_perf/scheduler_bench_test.go
+++ b/test/integration/scheduler_perf/scheduler_bench_test.go
@@ -162,7 +162,7 @@ func BenchmarkSchedulingMigratedInTreePVs(b *testing.B) {
 	// plugin, so the results should be comparable with BenchmarkSchedulingInTreePVs.
 	driverKey := util.GetCSIAttachLimitKey(testCSIDriver)
 	allocatable := map[v1.ResourceName]string{
-		v1.ResourceName(driverKey): fmt.Sprintf("%d", util.DefaultMaxEBSVolumes),
+		v1.ResourceName(driverKey): strconv.Itoa(util.DefaultMaxEBSVolumes),
 	}
 	var count int32 = util.DefaultMaxEBSVolumes
 	csiAllocatable := map[string]*storagev1beta1.VolumeNodeResources{
@@ -202,7 +202,7 @@ func BenchmarkSchedulingCSIPVs(b *testing.B) {
 	// plugin, so the results should be comparable with BenchmarkSchedulingInTreePVs.
 	driverKey := util.GetCSIAttachLimitKey(testCSIDriver)
 	allocatable := map[v1.ResourceName]string{
-		v1.ResourceName(driverKey): fmt.Sprintf("%d", util.DefaultMaxEBSVolumes),
+		v1.ResourceName(driverKey): strconv.Itoa(util.DefaultMaxEBSVolumes),
 	}
 	var count int32 = util.DefaultMaxEBSVolumes
 	csiAllocatable := map[string]*storagev1beta1.VolumeNodeResources{


### PR DESCRIPTION
This campaign refactors Go code by replacing `fmt.Sprintf("%d", number)` statements with the equivalent but clearer `strconv.Itoa(number)`.

It uses [Comby](https://comby.dev) to do the replacement and then runs `gofmt` over the repositories.

Here is the action definition:

```json
{
  "scopeQuery": "lang:go fmt.Sprintf(\"%d\", fork:yes -repo:sourcegraph-testing/go",
  "steps": [
    {
      "type": "docker", "image": "comby/comby",
      "args": [ "-in-place", "fmt.Sprintf(\"%d\", :[v])", "strconv.Itoa(:[v])", ".go", "-matcher", ".go", "-d", "/work", "-exclude-dir", ".,vendor" ]
    },
    { "type": "docker", "image": "golang:1.14-alpine", "args": ["sh", "-c", "cd /work && go fmt ./..."] }
  ]
}
```